### PR TITLE
Fix exceptions if neither label nor icon is set initially set for upload buttons

### DIFF
--- a/source/class/com/zenesis/qx/upload/UploadMgr.js
+++ b/source/class/com/zenesis/qx/upload/UploadMgr.js
@@ -209,10 +209,15 @@ qx.Class.define("com.zenesis.qx.upload.UploadMgr", {
       var data = this.__widgetsData[widget.toHashCode()];
       if (data && data.inputElement) {
         var bounds = widget.getBounds();
-        data.inputElement.setStyles({
-          width: bounds.width + "px",
-          height: bounds.height + "px"
-        });
+        // It may be that if the widgets icon is styled
+        // through a theme, neither label nor icon are set yet.
+        // In this situation bounds calculation would fail.
+        if(bounds) { 
+          data.inputElement.setStyles({
+            width: bounds.width + "px",
+            height: bounds.height + "px"
+          });
+        }
       }
     },
 


### PR DESCRIPTION
It may be that if the widgets icon is styled through a theme, neither label nor icon are set yet. In this situation bounds calculation would fail.